### PR TITLE
[WNMGDS-747] Fix release script

### DIFF
--- a/prepublish.sh
+++ b/prepublish.sh
@@ -25,10 +25,7 @@ BRANCH="release-$PACKAGE_VERSION"
 git checkout -b $BRANCH
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
-TAG="v$PACKAGE_VERSION"
-
-# Push up release branch containing the updated package versions
-git push --set-upstream origin $BRANCH
-git push origin $TAG
+# Push up release branch and tag containing the updated package versions
+git push --set-upstream origin $BRANCH --follow-tags
 
 echo "${GREEN}Prepublish complete. Make sure to merge the release branch $BRANCH into master...${NC}"

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -21,13 +21,14 @@ yarn build
 echo "${GREEN}Bumping version and creating a git tagged release commit...${NC}"
 yarn version
 PACKAGE_VERSION=$(node -pe "require('./package.json').version")
+BRANCH="release-$PACKAGE_VERSION"
+git checkout -b $BRANCH
 
 echo "${GREEN}Pushing tag and release commit to Github...${NC}"
 TAG="v$PACKAGE_VERSION"
 
-# Push up master branch containing the updated package versions
-git push --set-upstream origin master
-# Push up git tag containing the updated package versions
+# Push up release branch containing the updated package versions
+git push --set-upstream origin $BRANCH
 git push origin $TAG
 
-echo "${GREEN}Prepublish complete.${NC}"
+echo "${GREEN}Prepublish complete. Make sure to merge the release branch $BRANCH into master...${NC}"

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -21,12 +21,13 @@ yarn build
 echo "${GREEN}Bumping version and creating a git tagged release commit...${NC}"
 yarn version
 PACKAGE_VERSION=$(node -pe "require('./package.json').version")
-git commit -m "Bump package version to $PACKAGE_VERSION"
 
-echo "${GREEN}Pushing tag commit to Github...${NC}"
+echo "${GREEN}Pushing tag and release commit to Github...${NC}"
 TAG="v$PACKAGE_VERSION"
 
-# Push up release git tag containing the updated package versions
-git push --set-upstream origin $TAG
+# Push up master branch containing the updated package versions
+git push --set-upstream origin master
+# Push up git tag containing the updated package versions
+git push origin $TAG
 
 echo "${GREEN}Prepublish complete.${NC}"

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -18,20 +18,15 @@ echo "${GREEN}Building files and running tests...${NC}"
 yarn test
 yarn build
 
-echo "${GREEN}Bumping version and creating tagged release commit...${NC}"
-yarn bump
+echo "${GREEN}Bumping version and creating a git tagged release commit...${NC}"
+yarn version
 PACKAGE_VERSION=$(node -pe "require('./package.json').version")
-BRANCH="release-$PACKAGE_VERSION"
-git checkout -b $BRANCH
-git add package.json
 git commit -m "Bump package version to $PACKAGE_VERSION"
 
-echo "${GREEN}Pushing tag and release commit to Github...${NC}"
+echo "${GREEN}Pushing tag commit to Github...${NC}"
 TAG="v$PACKAGE_VERSION"
 
-# Push up release branch containing the updated package versions
-git push --set-upstream origin $BRANCH
-git tag $TAG
-git push origin $TAG
+# Push up release git tag containing the updated package versions
+git push --set-upstream origin $TAG
 
-echo "${GREEN}Prepublish complete. Make sure to merge the release branch $BRANCH into master...${NC}"
+echo "${GREEN}Prepublish complete.${NC}"


### PR DESCRIPTION
### Summary
- Add `yarn version` to bump package version. 
- This fixes `yarn bump` error on prepublish.sh script

### How to test
- `yarn version` to ensure this command is available