### PR TITLE
[NO_TICKET] Ensure consistent button styles in various states (focus, hover and active) 

### DIFF
--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -106,12 +106,26 @@
     color: $color-white;
     background-color: $button-primary-bg--active;
     border-color: $button-primary-bg--active;
+    &:focus,
+    &.ds-c-button--focus {
+      color: $color-white;
+      background-color: $button-primary-bg--active;
+    }
   }
 
   &:focus,
   &.ds-c-button--focus {
+    background-color: $button-primary-bg;
     border-color: $focus-choice-color;
     color: $color-white;
+    &:hover,
+    &.ds-c-button--hover {
+      background-color: $button-primary-bg--hover;
+    }
+    &:active,
+    &.ds-c-button--active {
+      background-color: $button-primary-bg--active;
+    }
   }
 
   &.ds-c-button--big {
@@ -128,12 +142,14 @@
 
     &:hover,
     &.ds-c-button--hover {
+      background-color: $color-white;
       border-color: rgba($color-gray-dark, 0.8);
       color: rgba($color-gray-dark, 0.8);
     }
 
     &:focus,
     &.ds-c-button--focus {
+      background-color: $color-white;
       border-color: rgba($color-gray-dark, 0.8);
       color: rgba($color-gray-dark, 0.8);
     }
@@ -155,7 +171,6 @@
       background-color: transparent;
       border-color: transparent;
       color: $color-white;
-
     }
   }
 }
@@ -185,5 +200,14 @@
   &:focus,
   &.ds-c-button--focus {
     border-color: $focus-choice-color;
+    background-color: $color-primary-alt;
+    &:hover,
+    &.ds-c-button--hover {
+      background-color: $color-primary-alt-dark;
+    }
+    &:active,
+    &.ds-c-button--active {
+      background-color: $color-primary-alt-light;
+    }
   }
 }

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -125,11 +125,6 @@
     }
   }
 
-  &.ds-c-button--big {
-    font-family: $montserrat-font;
-    font-weight: 600;
-  }
-
   // Primary white solid inverse button
   &.ds-c-button--inverse,
   &.ds-c-button--inverse:visited {
@@ -209,4 +204,10 @@
       background-color: $color-primary-alt-light;
     }
   }
+}
+
+// Big (landing page) button
+.ds-c-button--big {
+  font-family: $montserrat-font;
+  font-weight: 600;
 }

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -106,11 +106,6 @@
     color: $color-white;
     background-color: $button-primary-bg--active;
     border-color: $button-primary-bg--active;
-    &:focus,
-    &.ds-c-button--focus {
-      color: $color-white;
-      background-color: $button-primary-bg--active;
-    }
   }
 
   &:focus,
@@ -118,6 +113,8 @@
     background-color: $button-primary-bg;
     border-color: $focus-choice-color;
     color: $color-white;
+
+    // Ensure active and hover styles can be used with focus
     &:hover,
     &.ds-c-button--hover {
       background-color: $button-primary-bg--hover;
@@ -201,6 +198,8 @@
   &.ds-c-button--focus {
     border-color: $focus-choice-color;
     background-color: $color-primary-alt;
+
+    // Ensure active and hover styles can be used with focus
     &:hover,
     &.ds-c-button--hover {
       background-color: $color-primary-alt-dark;


### PR DESCRIPTION
In the Design system we updated focus buttons to set the focus styles to use the same text and background color as the hover styles for each button variation when the focus styles are not implemented https://github.com/CMSgov/design-system/pull/946

This caused issues in the Medicare child design system because their were custom styles that were causing conflicts.

This PR is to update the child design system to allow for these new styles to not break the current 
styling of buttons for Medicare 


**To test this PR**
- Pull down the cms design system repo and build the `WNMGDS-753-focus-state-button-fix` branch locally 
- Set the package.json file to use your local copy of the CMS Design system branch `WNMGDS-753-focus-state-button-fix`
- Run `git clean -fdx` to clear `node_modules`
- Run `yarn install` to install the CMS design system into the Medicare child design system locally
- Run `yarn start` to run the doc site
- Compare the button styles (default, hover, active and focus) you have locally with the GitHub doc site https://cmsgov.github.io/mgov-design-system/components/button/
- **You should see no difference between the 2 sites buttons.**

