### PR TITLE
BM/ Tertiary (outline inverse button) background color fix No Ticket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/ds-medicare-gov",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "publishConfig": {
     "tag": "latest",
     "access": "public"

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -52,6 +52,7 @@
   &.ds-c-button--inverse:visited {
     border-color: $color-white;
     color: $color-white;
+    background-color: transparent;
 
     &:hover,
     &.ds-c-button--hover {

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -50,6 +50,7 @@
   // default (tertiarty) outline inverse button
   &.ds-c-button--inverse,
   &.ds-c-button--inverse:visited {
+    background-color: transparent;
     border-color: $color-white;
     color: $color-white;
     background-color: transparent;

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -50,7 +50,6 @@
   // default (tertiarty) outline inverse button
   &.ds-c-button--inverse,
   &.ds-c-button--inverse:visited {
-    background-color: transparent;
     border-color: $color-white;
     color: $color-white;
     background-color: transparent;

--- a/src/styles/components/_override.buttons.scss
+++ b/src/styles/components/_override.buttons.scss
@@ -52,7 +52,6 @@
   &.ds-c-button--inverse:visited {
     border-color: $color-white;
     color: $color-white;
-    background-color: transparent;
 
     &:hover,
     &.ds-c-button--hover {


### PR DESCRIPTION
There was an issue where the SCSS was causing a teal background on the inverse tertiary button. 

Fix was to add a transparent class to the inverse outline button. 

Before:
![image (20)](https://user-images.githubusercontent.com/4505990/109707348-4bdbcf80-7b57-11eb-873a-c1d026fbff05.png)

After:
<img width="490" alt="Button - Medicare gov Design System 2021-03-02 13-01-27" src="https://user-images.githubusercontent.com/4505990/109707470-72016f80-7b57-11eb-9b60-b97d09aa6294.png">

Also to note: I had some confusion about commits and committed the same change a few different times. That was the reason for all the commits. 