### PR TITLE
Add unique key prop to Stars

### DIFF
--- a/src/components/Stars/Stars.tsx
+++ b/src/components/Stars/Stars.tsx
@@ -185,17 +185,20 @@ const Stars: FunctionComponent<StarsProps> = ({
   const emptyStars = totalStars - completeStars - (halfStar ? 1 : 0);
 
   const starIcons = [];
-
+  let starIndex = 0;
   for (let i = 0; i < completeStars; i++) {
-    starIcons.push(<FilledStar />);
+    starIcons.push(<FilledStar key={starIndex} />);
+    starIndex++;
   }
 
   if (halfStar) {
-    starIcons.push(<HalfStar />);
+    starIcons.push(<HalfStar key={starIndex} />);
+    starIndex++;
   }
 
   for (let i = 0; i < emptyStars; i++) {
-    starIcons.push(<EmptyStar />);
+    starIcons.push(<EmptyStar key={starIndex} />);
+    starIndex++;
   }
 
   return (


### PR DESCRIPTION
# Summary

The `Stars` component is missing `key` props.  It is displaying warnings like this:

```
Warning: Each child in a list should have a unique "key" prop.
```

This PR adds the missing `key` prop.

## How to test

Run `yarn test` in the master branch and you should see the warning.

Run `yarn test` in this PR branch and the warning should disappear.
