### PR TITLE
[WNMGDS-856] Add babel-plugin-typescript-to-proptypes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,7 @@ module.exports = function(api) {
   const plugins = [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
+    ['babel-plugin-typescript-to-proptypes', { comments: true }],
   ];
 
   return {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/webpack": "^4.41.6",
     "@typescript-eslint/eslint-plugin": "^2.21.0",
     "@typescript-eslint/parser": "^2.21.0",
+    "babel-plugin-typescript-to-proptypes": "^1.4.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-config-react": "^1.1.7",
@@ -62,7 +63,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@cmsgov/design-system": "2.5.0",
+    "@cmsgov/design-system": "file:../design-system/packages/design-system",
     "core-js": "^3.6.4",
     "lodash.uniqueid": "^4.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@cmsgov/design-system": "file:../design-system/packages/design-system",
+    "@cmsgov/design-system": "2.5.0",
     "core-js": "^3.6.4",
     "lodash.uniqueid": "^4.0.1"
   }


### PR DESCRIPTION
This adds support PropTypes support for legacy applications not using typescript.

To Test:
- Test on application not using typescript
- Import a mgov-design-system component (ie Card)
- Pass an invalid prop (IE, className={123})
- On master there is no error that number supplied instead of string. On this branch, there is error.