### PR TITLE
[NO-TICKET] Disable focus styles

### DIFF
--- a/src/styles/settings/_variables.build.scss
+++ b/src/styles/settings/_variables.build.scss
@@ -1,2 +1,5 @@
 // Includes rulesets to base html (i.e. applies styles to <a>)
 $ds-include-base-html-rulesets: false;
+
+// Disabling the design system focus styles
+$ds-include-focus-styles: false;


### PR DESCRIPTION
Disabling the focus styles at the Medicare level as they are not ready to start using the focus styles yet.

**How to test**
Run the Medicare design system locally linking to the master branch of the core design system and see that the focus styles match what is on the live documentation site