### PR TITLE
[NO-TICKET] Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    default_labels:
+    labels:
       - "Dependabot"
       - "Design System Update"
     allow:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry - checks daily
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    default_labels:
+      - "Dependabot"
+      - "Design System Update"
+    allow:
+      - dependency-name: "@cmsgov/design-system"
+      - dependency-name: "@cmsgov/design-system-docs"
+      - dependency-name: "@cmsgov/design-system-scripts"
+      # - More matches can be added here as time goes on for 
+      # security volunerability checks, etc


### PR DESCRIPTION
Was getting this issue on dependabot - I needed to change the `default_labels` to `labels` I think
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#labels

```
The property '#/updates/0/' contains additional properties ["default_labels"] outside of the schema when none are allowed
```


