### PR TITLE
Update Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: 'daily'
     labels:
-      - "Dependabot"
+      - "Dependencies"
       - "Design System Update"
     allow:
       - dependency-name: "@cmsgov/design-system"


### PR DESCRIPTION
Update Dependabot label to use the label `Dependencies` 

It could not find the "Dependabot" label see this PR 
https://github.com/CMSgov/mgov-design-system/pull/44#issuecomment-870854651
