### PR TITLE
[WNMGDS-921] link theming

### DIFF
--- a/src/styles/base/_override.links.scss
+++ b/src/styles/base/_override.links.scss
@@ -1,7 +1,7 @@
 // Links
 // Default link
 $link-color: $color-primary;
-$link-visited-color: #701e3c;
+$link-visited-color: $color-visited;
 $link-hover-color: $color-primary-darker;
 $link-active-color: $color-primary-darkest;
 

--- a/src/styles/base/_override.links.scss
+++ b/src/styles/base/_override.links.scss
@@ -1,49 +1,17 @@
-%link-inverse {
-  color: $color-white;
+// Links
+// Default link
+$link-color: $color-primary;
+$link-visited-color: #701e3c;
+$link-hover-color: $color-primary-darker;
+$link-active-color: $color-primary-darkest;
 
-  &:visited {
-    color: $color-white;
-  }
+// Inverse link
+$link-inverse-color: $color-base-inverse;
+$link-inverse-visited-color: $color-muted-inverse;
+$link-inverse-hover-color: $color-muted-inverse;
+$link-inverse-active-color: $color-muted-inverse;
 
-  &:hover,
-  &:active {
-    color: hsla(0, 0%, 100%, 0.77);
-  }
-}
-
-%link,
-%link-darker {
-  color: $color-primary-alt-light;
-
-  &:visited {
-    color: $color-visited;
-  }
-
-  // Override visited with hover
-  &:hover,
-  &:active {
-    color: $color-primary-alt;
-    outline: 0 none;
-  }
-
-  &:focus {
-    box-shadow: 0 0 0 4px $focus-choice-color-highlight,
-      0 0 0 2px $focus-choice-color;
-    border-color: $focus-choice-color;
-    outline: none;
-  }
-
-  &.mct-link--inverse {
-    @extend %link-inverse;
-  }
-}
-
-a,
-.ds-c-link {
-  @extend %link;
-}
-
-.ds-base--inverse a:not(.ds-c-button),
-.ds-c-link--inverse {
-  @extend %link-inverse;
-}
+// Link underline
+$link-underline-height: 1px;
+$link-underline-height-hover: 3px;
+$link-underline-offset: 0;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,17 +8,14 @@
  */
 
 // Settings: Globally-available variables, mixins, functions and config (Sass code that doesn't output CSS)
-@import "settings/index";
 @import "@cmsgov/design-system/dist/scss/settings/index";
+@import "settings/index";
 
 // Use custom font-faces
 @import "fonts";
 
 // Base: HTML elements (i.e. ds-base, ds-h1, ds-text), typography, links, icons
-// Everything from "@cmsgov/design-system/dist/scss/base/index" except links
-@import "@cmsgov/design-system/dist/scss/base/body.scss";
-@import "@cmsgov/design-system/dist/scss/base/icons.scss";
-@import "@cmsgov/design-system/dist/scss/base/typography.scss";
+@import "@cmsgov/design-system/dist/scss/base/index";
 @import "base/index";
 
 // Components: UI component styles (i.e. ds-c-button, ds-c-field)

--- a/src/styles/settings/_variables.build.scss
+++ b/src/styles/settings/_variables.build.scss
@@ -1,5 +1,5 @@
 // Includes rulesets to base html (i.e. applies styles to <a>)
-$ds-include-base-html-rulesets: false;
+$ds-include-base-html-rulesets: true;
 
 // Disabling the design system focus styles
 $ds-include-focus-styles: false;

--- a/src/styles/settings/_variables.color.scss
+++ b/src/styles/settings/_variables.color.scss
@@ -93,7 +93,7 @@ $color-error-light: $red-300;
 $color-error-lightest: $red-100;
 
 // Visited link color
-$color-visited: $color-primary-alt-light;
+$color-visited: #701e3c;
 
 $color-base: $color-gray-dark;
 // Due to missing !default in core, this wont work until core fixes it


### PR DESCRIPTION
## Summary
Setting up link theming for the Medicare design system theme

### Added
- Added link variables 

### Removed
- Duplicate styling that was copied from the core and not needed

### Fixed
- Set `ds-include-base-html-rulesets: true;` becasue Mgov is directly styling the A tag 

## How to test
- Build this branch of the core design system WNMGDS-921-add-link-theming 
- Link to the core design system locally
- install and run the Mgov doc site locally 
- See that the link styling matches what is [found here in Sketch ](https://www.sketch.com/s/33f9c38c-9da3-4d40-b1a7-e7805166ed23/a/1Keg294)
- link to the local version of the mgov ds on a few products to test as well