### PR TITLE
[NO-TICKET] Add e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ These scripts can all be run from the root level of the repo:
   - Compiles and processes all the code and assets and copies them to the `dist` directory so that they're ready for distribution and consumption as a package
 - `yarn test`
   - Runs JS unit tests
+- `yarn test:e2e`
+  - Runs end to end tests
 - `yarn update-snapshots`
   - Updates [Jest snapshots](http://facebook.github.io/jest/docs/en/snapshot-testing.html)
 - `yarn lint`

--- a/docs/src/pages/components/Card/Card.docs.scss
+++ b/docs/src/pages/components/Card/Card.docs.scss
@@ -7,7 +7,7 @@ Style guide: components.card
 /*
 `<Card>`
 
-@react-component Card.example.tsx
+@react-example Card.example.tsx
 
 @react-props Card.tsx
 

--- a/docs/src/pages/components/Caret/Caret.docs.scss
+++ b/docs/src/pages/components/Caret/Caret.docs.scss
@@ -35,7 +35,7 @@ Markup:
 */
 
 /*
-React
+`<Caret>`
 
 @react-example Caret.example.tsx
 

--- a/docs/src/pages/components/CloseSymbol/CloseSymbol.docs.scss
+++ b/docs/src/pages/components/CloseSymbol/CloseSymbol.docs.scss
@@ -34,7 +34,7 @@ Style guide: components.close-icon
 */
 
 /*
-`<CloseSymbol>`
+`<Close>`
 
 @react-example CloseSymbol.example.tsx
 

--- a/docs/src/pages/components/HamburgerSymbol/HamburgerSymbol.docs.scss
+++ b/docs/src/pages/components/HamburgerSymbol/HamburgerSymbol.docs.scss
@@ -33,7 +33,7 @@ Style guide: components.hamburger-icon
 */
 
 /*
-`<HamburgerSymbol>`
+`<Hamburger>`
 
 @react-example HamburgerSymbol.example.tsx
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "build": "yarn cmsds build-docs --skipLatest",
     "start": "yarn cmsds start --skipLatest",
-    "test": "yarn cmsds test ./src",
+    "test": "yarn test:unit && yarn test:e2e",
+    "test:unit": "yarn cmsds test ./src",
+    "test:e2e": "yarn cmsds test:e2e ./src",
     "lint": "yarn cmsds lint ./src ./docs/src --disableStylelint",
     "gh-pages": "yarn build && gh-pages -d './docs/dist'",
     "release": "./prepublish.sh"

--- a/src/components/Card/Card.e2e.test.js
+++ b/src/components/Card/Card.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementByClassName } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.card.react/`;
+
+describe('Card component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementByClassName('m-c-card');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/Caret/Caret.e2e.test.js
+++ b/src/components/Caret/Caret.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.caret-icon.react/`;
+
+describe('Caret component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/Checkmark/Checkmark.e2e.test.js
+++ b/src/components/Checkmark/Checkmark.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.checkmark-icon.react/`;
+
+describe('Checkmark component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/CloseSymbol/CloseSymbol.e2e.test.js
+++ b/src/components/CloseSymbol/CloseSymbol.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.close-icon.react/`;
+
+describe('CloseSymbol component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/GlobalHeader/GlobalHeader.e2e.test.js
+++ b/src/components/GlobalHeader/GlobalHeader.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementByClassName } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.global-header.react/`;
+
+describe('GlobalHeader component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementByClassName('m-c-globalHeader');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/HHSlogo/HHSlogo.e2e.test.js
+++ b/src/components/HHSlogo/HHSlogo.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.HHS-icon.react/`;
+
+describe('HHSLogo component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/HamburgerSymbol/HamburgerSymbol.e2e.test.js
+++ b/src/components/HamburgerSymbol/HamburgerSymbol.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.hamburger-icon.react/`;
+
+describe('HamburgerSymbol component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/MedicaregovLogo/MedicaregovLogo.e2e.test.js
+++ b/src/components/MedicaregovLogo/MedicaregovLogo.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.medicaregov-icon.react/`;
+
+describe('MedicaregovLogo component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/Navbar/Navbar.e2e.test.js
+++ b/src/components/Navbar/Navbar.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementByClassName } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.navbar.react/`;
+
+describe('Navbar component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementByClassName('m-c-navbar');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/NavigationMenu/NavigationMenu.e2e.test.js
+++ b/src/components/NavigationMenu/NavigationMenu.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementByClassName } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.navigation-menu.react/`;
+
+describe('NavigationMenu component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementByClassName('m-c-navigationMenu__container');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/No/No.e2e.test.js
+++ b/src/components/No/No.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.No.react/`;
+
+describe('No component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/SimpleFooter/SimpleFooter.e2e.test.js
+++ b/src/components/SimpleFooter/SimpleFooter.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementByClassName } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.simple-footer.react/`;
+
+describe('SimpleFooter component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementByClassName('m-c-footer');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});

--- a/src/components/Stars/Stars.e2e.test.js
+++ b/src/components/Stars/Stars.e2e.test.js
@@ -1,0 +1,19 @@
+import { ROOT_URL } from '@cmsgov/design-system-scripts/helpers/e2e/constants';
+
+import assertNoAxeViolations from '@cmsgov/design-system-scripts/helpers/e2e/assertNoAxeViolations';
+import { getElementById } from '@cmsgov/design-system-scripts/helpers/e2e';
+
+const rootURL = `${ROOT_URL}/example/components.stars-icons.react/`;
+
+describe('Stars component', () => {
+  it('Should render', async () => {
+    await driver.get(rootURL);
+
+    const el = await getElementById('js-example');
+    expect(el).toBeTruthy();
+  });
+  
+  it('Should have no accessibility violations', async () => {
+    await assertNoAxeViolations(rootURL);
+  });
+});


### PR DESCRIPTION
## Summary
Add e2e tests for the react components. These tests use the [e2e-test helpers](https://github.com/CMSgov/design-system/pull/1030) which was recently provided by the Core design system package.

## How to test
- Run `yarn test`
- Run `yarn test:e2e`
- Run `yarn start` and check the following components are displayed correctly:
   - Card
   - Caret
   - Close symbol
   - Hamburger symbol