### PR TITLE
Bug fix - Adding typography-body.example.html page to build

### DIFF
--- a/docs/src/pages/styles/typography/typography-body.example.html
+++ b/docs/src/pages/styles/typography/typography-body.example.html
@@ -1,0 +1,14 @@
+<section class="example--list">
+  <article>
+    <code class="ds-u-margin-y--0 ds-u-margin-bottom--1">.ds-text-body--lg</code>
+    <p class="ds-text-body--lg ds-text--lead">{{lorem-l}}</p>
+  </article>
+  <article>
+    <code class="ds-u-margin-y--0 ds-u-margin-bottom--1">.ds-text-body--md</code>
+    <p class="ds-text-body--md ds-text">{{lorem-l}}</p>
+  </article>
+  <article>
+    <code class="ds-u-margin-y--0 ds-u-margin-bottom--1">.ds-text-body--sm</code>
+    <p class="ds-text-body--sm">{{lorem-l}}</p>
+  </article>
+</section>


### PR DESCRIPTION
## Summary
Build error created when doc generation was looking for a file that couldn't be found. Fixed error by adding typography-body.example.html file back to build. 

### Added
Added typography-body.example.html file to docs folder for typography.

## How to test
Run yarn test locally. 
