### PR TITLE
No ticket: Reset border width for input fields in error state

### DIFF
--- a/src/styles/components/_override.forms.scss
+++ b/src/styles/components/_override.forms.scss
@@ -17,12 +17,11 @@
   font-family: $rubik-font;
   font-size: $font-size-md;
   border-radius: 3px;
-  border: 1px solid $black-200;
+  border-color: $black-200;
   padding: $spacer-2;
 
   &--error {
     border-color: $red-500;
-    border-width: 3px;
   }
 }
 

--- a/src/styles/components/_override.forms.scss
+++ b/src/styles/components/_override.forms.scss
@@ -22,6 +22,7 @@
 
   &--error {
     border-color: $red-500;
+    border-width: 3px;
   }
 }
 


### PR DESCRIPTION
It looks like the override for the unmodified border class is resetting the width of the border on inputs in error. Re-add the declaration for border width for all inputs in a modified state of `--error`

For reference, see [CMSDS TextField CSS](https://github.com/CMSgov/design-system/blob/6757cb3f9b676c0bf010b37b120b1f928de527ef/packages/design-system/src/styles/components/_TextField.scss#L61) and [MCT-6020](https://jira.cms.gov/browse/MCT-6020)

**Please follow the format below and remove any sections that aren't relevant.**
## Summary
Re-applies form field error-state border width of 3px, from the CMSDS

### Changed
<img src="https://user-images.githubusercontent.com/771447/141365827-925224c6-1ddc-4592-a8de-2b5c335824b9.png" width="525" />
<img src="https://user-images.githubusercontent.com/771447/141365926-105ce499-556d-4e56-aa24-98c1c1fdbe8b.png" width="525" />

## How to test
The easiest thing to do is look at the live component library and change `border: 1px solid $black-200` to `border-color: $black-200` the `.ds-c-field` selector (nested in source)